### PR TITLE
Hotfix Snap Packaging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,9 @@ jobs:
             - libzip-dev
             - libzzip-0-13
             - lsb-release
-            - libssl1.0-dev
-            - nodejs-dev
-            - node-gyp
+            - libssl1.0-dev  # dependency of npm
+            - nodejs-dev     # dependency of npm
+            - node-gyp       # dependency of npm
             - npm
             - openjdk-11-jdk
             - pbzip2

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ jobs:
             - libzip-dev
             - libzzip-0-13
             - lsb-release
+            - libssl1.0-dev
             - nodejs-dev
             - node-gyp
             - npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ jobs:
             - libzip-dev
             - libzzip-0-13
             - lsb-release
+            - node-gyp
             - npm
             - openjdk-11-jdk
             - pbzip2

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ jobs:
             - libzip-dev
             - libzzip-0-13
             - lsb-release
+            - nodejs-dev
             - node-gyp
             - npm
             - openjdk-11-jdk

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -99,6 +99,7 @@ parts:
     - libzip-dev
     - libzzip-0-13
     - lsb-release
+    - nodejs-dev
     - node-gyp
     - npm
     - openjdk-11-jdk

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -99,9 +99,9 @@ parts:
     - libzip-dev
     - libzzip-0-13
     - lsb-release
-    - libssl1.0-dev
-    - nodejs-dev
-    - node-gyp
+    - libssl1.0-dev  # dependency of npm
+    - nodejs-dev     # dependency of npm
+    - node-gyp       # dependency of npm
     - npm
     - openjdk-11-jdk
     - pbzip2

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -99,6 +99,7 @@ parts:
     - libzip-dev
     - libzzip-0-13
     - lsb-release
+    - node-gyp
     - npm
     - openjdk-11-jdk
     - pbzip2

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -99,6 +99,7 @@ parts:
     - libzip-dev
     - libzzip-0-13
     - lsb-release
+    - libssl1.0-dev
     - nodejs-dev
     - node-gyp
     - npm


### PR DESCRIPTION
The creation of the snap package is now failing due to an issue while installing the dependencies.