### PR TITLE
Fixed obsolete command

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -2,7 +2,7 @@
 
 count=0
 version=`cat webots/resources/version.txt`
-until snapcraft push webots_${version}_amd64.snap
+until snapcraft upload webots_${version}_amd64.snap
 do
   (( count ++ ))
   echo "Trying again ($count)"


### PR DESCRIPTION
The snapcraft "push" command is now obsolete, replaced by "upload".