### PR TITLE
Fixed upload script to handle revisions names

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -2,6 +2,7 @@
 
 count=0
 version=`cat webots/resources/version.txt`
+version=${version/ revision /-rev}
 until snapcraft upload webots_${version}_amd64.snap
 do
   (( count ++ ))


### PR DESCRIPTION
The upload script was unable to handle versions of Webots including revision.