### PR TITLE
Add xvfb dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ jobs:
           packages:
             - git
             - python-pip
+            - xvfb
       before_install:
         - sudo snap install snapcraft --classic
         - pip install PyGithub # used to upload packages to Github releases

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -77,6 +77,7 @@ parts:
     build-packages:
     - git
     - python-pip
+    - xvfb
     plugin: make
     build-environment:
     - WEBOTS_HOME: "$SNAPCRAFT_PART_BUILD"


### PR DESCRIPTION
Follow up https://github.com/cyberbotics/webots/pull/2466 and #22:
> The build of the snap fails on a stock bionic system because xvfb is not installed.