### PR TITLE
Improve upload of GitHub action artifacts

### DIFF
--- a/.github/workflows/snap-creation.yml
+++ b/.github/workflows/snap-creation.yml
@@ -87,12 +87,6 @@ jobs:
       run: |
         sudo snapcraft --destructive-mode
         cp *.snap webots/distribution
-    - uses: actions/upload-artifact@v2
-      if: ${{ contains(github.event.pull_request.labels.*.name, 'test creation') }}
-      with:
-        name: build-${{ github.ref }}
-        path: |
-          webots/distribution/*.snap
     - name: Create/Update `webots` GitHub Release
       run: |
         export COMMIT_ID=$(cd webots; git rev-parse HEAD)

--- a/.github/workflows/snap-creation.yml
+++ b/.github/workflows/snap-creation.yml
@@ -51,6 +51,7 @@ jobs:
         sudo snapcraft --destructive-mode
         cp *.snap webots/distribution
     - uses: actions/upload-artifact@v2
+      if: ${{ contains(github.event.pull_request.labels.*.name, 'test creation') }}
       with:
         name: build-${{ matrix.branch }}
         path: |
@@ -87,6 +88,7 @@ jobs:
         sudo snapcraft --destructive-mode
         cp *.snap webots/distribution
     - uses: actions/upload-artifact@v2
+      if: ${{ contains(github.event.pull_request.labels.*.name, 'test creation') }}
       with:
         name: build-${{ github.ref }}
         path: |


### PR DESCRIPTION
Upload package as artifact only when testing, i.e. when the `test creation` label is set.
On schedule and tag push the package is published directly in the https://github.com/cyberbotics/webots repository so there is no need to upload it as an artifact.