### PR TITLE
Hotfix conflicts in installation of libzip-dev

### DIFF
--- a/.github/workflows/snap-creation.yml
+++ b/.github/workflows/snap-creation.yml
@@ -28,6 +28,12 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
+    - name: Install libzip-dev
+      run: |
+        # GitHub Actions `libzip-dev` hotfix
+        sudo apt purge libzip4
+        sudo apt autoremove
+        sudo apt install -y libzip-dev
     - name: Install Snapcraft
       uses: samuelmeuli/action-snapcraft@v1
     - name: Clone Webots Repository (build)


### PR DESCRIPTION
Fix conflicts when installing libzip-dev on the GitHub Actions container.
Related to https://github.com/cyberbotics/webots/pull/3050.