### PR TITLE
Remove broken step on release tag even

### DIFF
--- a/.github/workflows/snap-creation.yml
+++ b/.github/workflows/snap-creation.yml
@@ -98,6 +98,3 @@ jobs:
         export COMMIT_ID=$(cd webots; git rev-parse HEAD)
         sudo python -m pip install requests PyGithub
         webots/scripts/packaging/publish_release.py --key=${{ secrets.BOT_ACTION_KEY }} --repo=cyberbotics/webots --branch=${{ github.ref }} --commit=$COMMIT_ID --tag=${{ github.ref }}
-    - name: Create/Update `webots-snap` GitHub Release
-      run: |
-        webots/scripts/packaging/publish_release.py --key=${{ secrets.GITHUB_TOKEN }} --repo=${{ github.repository }} --branch=${{ github.ref }} --commit=$COMMIT_ID --tag=${{ github.ref }}


### PR DESCRIPTION
Publishing a release on the `webots_snap` repository when a tag is pushed is currently throwing errors (see for example https://github.com/cyberbotics/webots-snap/runs/3010171575?check_suite_focus=true).

One issue is that the wrong commit ID is used: commit ID refers to the `webots` repository and not to the `webots-snap`.
This could be easily solved, but I don't know if there are other issues.
In any case, we are probably not interested in creating a release page on this repository (we never did) so it seems better to simply remove the step.
