### PR TITLE
revert config file to core18

### DIFF
--- a/.github/workflows/snap-creation.yml
+++ b/.github/workflows/snap-creation.yml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
   cleanup-runs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@v0.3.0
       env:
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         branch: [master, develop]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - name: Install libzip-dev
@@ -40,7 +40,7 @@ jobs:
       run: |
         sudo apt install --yes git
         sudo snap install snapcraft --classic
-        export ROS_DISTRO=noetic
+        export ROS_DISTRO=melodic
         git clone --recurse-submodules --depth 3 --single-branch --branch ${{ matrix.branch }} https://github.com/cyberbotics/webots.git
         export WEBOTS_VERSION=$(cat webots/scripts/packaging/webots_version.txt | sed 's/ revision /-rev/g')
         sed -i "s/version:\s*'R[0-9]\{4\}[a-z].*'/version: '$WEBOTS_VERSION'/g" snapcraft.yaml
@@ -54,8 +54,7 @@ jobs:
         Xvfb :99 -screen 0 1024x768x16 &
     - name: Create Snap Package
       run: |
-        sudo apt update --yes
-        sudo snapcraft --destructive-mode --enable-experimental-extensions
+        sudo snapcraft --destructive-mode
         cp *.snap webots/distribution
     - uses: actions/upload-artifact@v2
       if: ${{ contains(github.event.pull_request.labels.*.name, 'test creation') }}
@@ -72,7 +71,7 @@ jobs:
   release-tag:
     needs: cleanup-runs
     if: ${{ github.event_name == 'push' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - name: Install Snapcraft
@@ -81,7 +80,7 @@ jobs:
       run: |
         sudo apt install --yes git
         sudo snap install snapcraft --classic
-        export ROS_DISTRO=noetic
+        export ROS_DISTRO=melodic
         git clone --recurse-submodules --depth 3 --single-branch --branch ${GITHUB_REF#refs/tags/} https://github.com/cyberbotics/webots.git
         export WEBOTS_VERSION=$(cat webots/scripts/packaging/webots_version.txt | sed 's/ revision /-rev/g')
         sed -i "s/version:\s*'R[0-9]\{4\}[a-z].*'/version: '$WEBOTS_VERSION'/g" snapcraft.yaml
@@ -92,7 +91,7 @@ jobs:
         Xvfb :99 -screen 0 1024x768x16 &
     - name: Create Snap Package
       run: |
-        sudo snapcraft --destructive-mode --enable-experimental-extensions
+        sudo snapcraft --destructive-mode
         cp *.snap webots/distribution
     - name: Create/Update `webots` GitHub Release
       run: |

--- a/.github/workflows/snap-creation.yml
+++ b/.github/workflows/snap-creation.yml
@@ -24,7 +24,7 @@ jobs:
     if: ${{ github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'test creation') }}
     strategy:
       matrix:
-        branch: [master, develop]
+        branch: [master, develop, fix-revert-core18]
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/snap-creation.yml
+++ b/.github/workflows/snap-creation.yml
@@ -24,7 +24,7 @@ jobs:
     if: ${{ github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'test creation') }}
     strategy:
       matrix:
-        branch: [fix-revert-core18]
+        branch: [master, develop]
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/snap-creation.yml
+++ b/.github/workflows/snap-creation.yml
@@ -24,7 +24,7 @@ jobs:
     if: ${{ github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'test creation') }}
     strategy:
       matrix:
-        branch: [master, develop, fix-revert-core18]
+        branch: [fix-revert-core18]
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -117,15 +117,18 @@ parts:
     - libdbus-1-3
     - libdouble-conversion1
     - libdrm-common
+    - libfox-1.6-dev
     - libfreeimage3
     - libfreetype6
     - libgcc1
     - libgcrypt20
     - libgd3
+    - libgdal-dev
     - libgeos-dev
     - libgfortran4
     - libglib2.0-0
     - libgl1
+    - libgl2ps-dev
     - libglu1-mesa
     - libglvnd0
     - libglx0
@@ -155,9 +158,12 @@ parts:
     - libopencore-amrwb0
     - libopus0
     - libpcre3
+    - libpoco-dev
     - libproj12
+    - libproj-dev
     - libpsl5
     - libpulse-mainloop-glib0
+    - libpython2.7
     - libroken18-heimdal
     - librtmp1
     - libsasl2-2
@@ -176,6 +182,7 @@ parts:
     - libsystemd0
     - libtheora0
     - libtinfo5
+    - libtinyxml2-6
     - libtwolame0
     - libudev1
     - libuuid1
@@ -202,6 +209,7 @@ parts:
     - libxcb-xfixes0
     - libxcb-xinerama0
     - libxcb-xkb1
+    - libxerces-c-dev
     - libxft2
     - libxkbcommon-x11-0
     - libxrandr2

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -43,8 +43,6 @@ layout:
     bind: $SNAP/usr/lib/x86_64-linux-gnu
   /usr/share/libdrm:  # to fix a warning displayed by Webots on AMD GPUs
     bind: $SNAP/usr/share/libdrm
-  /usr/lib/libgdal.so:
-    bind: $SNAP/usr/lib/libgdal.so
 
 parts:
   desktop-gtk3:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -39,10 +39,12 @@ layout:
     bind: $SNAP/etc/openal
   /usr/include:  # to allow gcc compiler to find system include files
     bind: $SNAP/usr/include
-  /usr/lib:  # to allow gcc linker to find the necessary libraries
-    bind: $SNAP/usr/lib
+  /usr/lib/x86_64-linux-gnu:  # to allow gcc linker to find the necessary libraries
+    bind: $SNAP/usr/lib/x86_64-linux-gnu
   /usr/share/libdrm:  # to fix a warning displayed by Webots on AMD GPUs
     bind: $SNAP/usr/share/libdrm
+  /usr/lib/libgdal.so:
+    bind: $SNAP/usr/lib/libgdal.so
 
 parts:
   desktop-gtk3:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,17 +2,17 @@
 # unset LD_LIBRARY_PATH
 # unset JAVA_HOME
 # snapcraft  # --destructive-mode may be needed if run on a virtual machine
-# snap install --dangerous webots_R2022a_amd64.snap
+# snap install --dangerous webots_R2021a_amd64.snap
 # webots
 # snap uninstall webots
 # snapcraft login
-# snapcraft push webots_R2022a_amd64.snap
+# snapcraft push webots_R2021a_amd64.snap
 # snap install webots
 
 name: webots
 title: Webots
-base: core20
-adopt-info: 'webots'
+base: core18
+version: 'R2021b'
 summary: Webots is a free and open-source 3D robot simulator
 description: |
   Webots is a free and open-source 3D robot simulator.
@@ -31,7 +31,7 @@ architectures:
 - build-on: amd64
   run-on: amd64
 environment:
-  JAVA_HOME: "$SNAP/usr/lib/jvm/java-16-openjdk-amd64"
+  JAVA_HOME: "$SNAP/usr/lib/jvm/java-11-openjdk-amd64"
   PATH: "$JAVA_HOME/bin:$PATH"
 
 layout:
@@ -39,6 +39,8 @@ layout:
     bind: $SNAP/etc/openal
   /usr/include:  # to allow gcc compiler to find system include files
     bind: $SNAP/usr/include
+  /usr/lib/x86_64-linux-gnu:  # to allow gcc linker to find the necessary libraries
+    bind: $SNAP/usr/lib/x86_64-linux-gnu
   /usr/share/libdrm:  # to fix a warning displayed by Webots on AMD GPUs
     bind: $SNAP/usr/share/libdrm
 
@@ -74,12 +76,12 @@ parts:
   webots:
     build-packages:
     - git
-    - python3-pip
+    - python-pip
     plugin: make
     build-environment:
     - WEBOTS_HOME: "$SNAPCRAFT_PART_BUILD"
-    - ROS_DISTRO: "noetic"
-    - JAVA_HOME: "/usr/lib/jvm/java-16-openjdk-amd64"
+    - ROS_DISTRO: "melodic"
+    - JAVA_HOME: "/usr/lib/jvm/java-1.11.0-openjdk-amd64"
     - PATH: "$JAVA_HOME/bin:$PATH"
     #source: https://cyberbotics.com/files/repository/beta/webots.tar.bz2
     # When building locally, uncomment the following line:
@@ -91,44 +93,39 @@ parts:
     #source-depth: 1
     #source-branch: feature-snapcraft-build
     # We should specify either the source-branch or the source-tag, but not both
-    # source-tag: R2022a
+    # source-tag: R2019b
     override-pull: |
       snapcraftctl pull
       ./scripts/install/linux_optional_compilation_dependencies.sh
       sudo apt install --yes xvfb
-      snapcraftctl set-version R2022a
     stage-packages:
-    - openjdk-16-jdk
+    - openjdk-11-jdk
     - ca-certificates-java
     - build-essential
     - libc6-dev
     - ffmpeg
     - freeglut3-dev
-    - libaribb24-0
     - libasn1-8-heimdal
     - libasound2
     - libatk1.0-0
-    - libavutil56
+    - libavutil55
     - libblkid1
     - libcanberra-gtk-module
     - libcanberra-gtk3-module
     - libcrystalhd3
     - libcurl3-gnutls
     - libdbus-1-3
-    - libdouble-conversion3
+    - libdouble-conversion1
     - libdrm-common
-    - libfox-1.6-dev
     - libfreeimage3
     - libfreetype6
     - libgcc1
     - libgcrypt20
     - libgd3
-    - libgdal-dev
     - libgeos-dev
     - libgfortran4
     - libglib2.0-0
     - libgl1
-    - libgl2ps-dev
     - libglu1-mesa
     - libglvnd0
     - libglx0
@@ -141,7 +138,7 @@ parts:
     - libheimbase1-heimdal
     - libheimntlm0-heimdal
     - libhx509-5-heimdal
-    - libicu66
+    - libicu60
     - libjpeg8-dev
     - libkrb5-26-heimdal
     - libldap-2.4-2
@@ -158,9 +155,9 @@ parts:
     - libopencore-amrwb0
     - libopus0
     - libpcre3
-    - libproj15
-    - libproj-dev
+    - libproj12
     - libpsl5
+    - libpulse-mainloop-glib0
     - libroken18-heimdal
     - librtmp1
     - libsasl2-2
@@ -168,18 +165,17 @@ parts:
     - libshine3
     - libslang2
     - libsnappy1v5
-    - libsndio7.0
+    - libsndio6.1
     - libsoxr0
     - libspeex1
     - libssh-dev
     - libssh-gcrypt-4
     - libssl1.1
     - libstdc++6
-    - libswresample3
+    - libswresample2
     - libsystemd0
     - libtheora0
     - libtinfo5
-    - libtinyxml2-dev
     - libtwolame0
     - libudev1
     - libuuid1
@@ -192,7 +188,7 @@ parts:
     - libwind0-heimdal
     - libx11-data
     - libx11-xcb1
-    - libx265-179
+    - libx265-146
     - libxaw7
     - libxcb-glx0
     - libxcb-icccm4
@@ -206,7 +202,6 @@ parts:
     - libxcb-xfixes0
     - libxcb-xinerama0
     - libxcb-xkb1
-    - libxerces-c-dev
     - libxft2
     - libxkbcommon-x11-0
     - libxrandr2
@@ -226,22 +221,25 @@ parts:
 
 apps:
   webots:
-    extensions: [gnome-3-38]
     environment:
       LANG: C.UTF-8
       LC_ALL: C.UTF-8
       DISABLE_WAYLAND: 1
     plugs:
-      - audio-playback
-      - browser-support
-      - gsettings
-      - hidraw
-      - home
-      - hostname-control
-      - joystick
-      - network
-      - unity7
+    - audio-playback
+    - browser-support
+    - desktop
+    - desktop-legacy
+    - gsettings
+    - hidraw
+    - home
+    - hostname-control
+    - joystick
+    - network
+    - opengl
+    - pulseaudio
+    - wayland
+    - unity7
+    - x11
     desktop: usr/share/webots/resources/webots.desktop
-    command-chain:
-      - bin/desktop-launch
-    command: usr/share/webots/webots
+    command: desktop-launch $SNAP/usr/share/webots/webots

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -39,8 +39,8 @@ layout:
     bind: $SNAP/etc/openal
   /usr/include:  # to allow gcc compiler to find system include files
     bind: $SNAP/usr/include
-  /usr/lib/x86_64-linux-gnu:  # to allow gcc linker to find the necessary libraries
-    bind: $SNAP/usr/lib/x86_64-linux-gnu
+  /usr/lib:  # to allow gcc linker to find the necessary libraries
+    bind: $SNAP/usr/lib
   /usr/share/libdrm:  # to fix a warning displayed by Webots on AMD GPUs
     bind: $SNAP/usr/share/libdrm
 


### PR DESCRIPTION
We decided to revert to core18 for the release because gcc and sumo were not working.

It is probably due to the issue described here: 
https://forum.snapcraft.io/t/layouts-conflicts-due-to-extension/27948