### PR TITLE
Move from Ubuntu 18.04 to Ubuntu 20.04

### DIFF
--- a/.github/workflows/snap-creation.yml
+++ b/.github/workflows/snap-creation.yml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
   cleanup-runs:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@v0.3.0
       env:
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         branch: [master, develop]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Install libzip-dev
@@ -71,7 +71,7 @@ jobs:
   release-tag:
     needs: cleanup-runs
     if: ${{ github.event_name == 'push' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Install Snapcraft

--- a/.github/workflows/snap-creation.yml
+++ b/.github/workflows/snap-creation.yml
@@ -44,6 +44,7 @@ jobs:
         git clone --recurse-submodules --depth 3 --single-branch --branch ${{ matrix.branch }} https://github.com/cyberbotics/webots.git
         export WEBOTS_VERSION=$(cat webots/scripts/packaging/webots_version.txt | sed 's/ revision /-rev/g')
         sed -i "s/version:\s*'R[0-9]\{4\}[a-z].*'/version: '$WEBOTS_VERSION'/g" snapcraft.yaml
+        sed -i "s/set-version R[0-9]\{4\}[a-z].*/set-version: $WEBOTS_VERSION/g" snapcraft.yaml
     - name: Set Commit SHA in Version
       if: ${{ github.event_name == 'schedule' }}
       run: python webots/scripts/packaging/set_commit_and_date_in_version.py ${{ github.sha }}

--- a/.github/workflows/snap-creation.yml
+++ b/.github/workflows/snap-creation.yml
@@ -44,7 +44,7 @@ jobs:
         git clone --recurse-submodules --depth 3 --single-branch --branch ${{ matrix.branch }} https://github.com/cyberbotics/webots.git
         export WEBOTS_VERSION=$(cat webots/scripts/packaging/webots_version.txt | sed 's/ revision /-rev/g')
         sed -i "s/version:\s*'R[0-9]\{4\}[a-z].*'/version: '$WEBOTS_VERSION'/g" snapcraft.yaml
-        sed -i "s/set-version R[0-9]\{4\}[a-z].*/set-version: $WEBOTS_VERSION/g" snapcraft.yaml
+        sed -i "s/set-version\s*R[0-9]\{4\}[a-z].*/set-version $WEBOTS_VERSION/g" snapcraft.yaml
     - name: Set Commit SHA in Version
       if: ${{ github.event_name == 'schedule' }}
       run: python webots/scripts/packaging/set_commit_and_date_in_version.py ${{ github.sha }}

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -96,7 +96,7 @@ parts:
     # source-tag: R2022a
     override-pull: |
       snapcraftctl pull
-      # ./scripts/install/linux_optional_compilation_dependencies.sh
+      ./scripts/install/linux_optional_compilation_dependencies.sh
       sudo apt install --yes xvfb
       snapcraftctl set-version R2022b
     stage-packages:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -111,7 +111,6 @@ parts:
     - libasound2
     - libatk1.0-0
     - libavutil56
-    - libblas3
     - libblkid1
     - libcanberra-gtk-module
     - libcanberra-gtk3-module
@@ -235,7 +234,6 @@ apps:
       LANG: C.UTF-8
       LC_ALL: C.UTF-8
       DISABLE_WAYLAND: 1
-      LD_LIBRARY_PATH: $LD_LIBRARAY_PATH:/lib/x86_64-linux-gnu/blas
     plugs:
       - audio-playback
       - browser-support

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -11,7 +11,7 @@
 
 name: webots
 title: Webots
-base: core18
+base: core20
 version: 'R2021b'
 summary: Webots is a free and open-source 3D robot simulator
 description: |

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -12,7 +12,7 @@
 name: webots
 title: Webots
 base: core20
-version: 'R2022a'
+version: 'R2022b'
 summary: Webots is a free and open-source 3D robot simulator
 description: |
   Webots is a free and open-source 3D robot simulator.
@@ -31,7 +31,7 @@ architectures:
 - build-on: amd64
   run-on: amd64
 environment:
-  JAVA_HOME: "$SNAP/usr/lib/jvm/java-11-openjdk-amd64"
+  JAVA_HOME: "$SNAP/usr/lib/jvm/java-16-openjdk-amd64"
   PATH: "$JAVA_HOME/bin:$PATH"
 
 layout:
@@ -39,10 +39,10 @@ layout:
     bind: $SNAP/etc/openal
   /usr/include:  # to allow gcc compiler to find system include files
     bind: $SNAP/usr/include
-  /usr/lib/x86_64-linux-gnu:  # to allow gcc linker to find the necessary libraries
-    bind: $SNAP/usr/lib/x86_64-linux-gnu
   /usr/share/libdrm:  # to fix a warning displayed by Webots on AMD GPUs
     bind: $SNAP/usr/share/libdrm
+  /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libc_nonshared.a:
+    bind-file: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libc_nonshared.a
 
 parts:
   desktop-gtk3:
@@ -76,12 +76,12 @@ parts:
   webots:
     build-packages:
     - git
-    - python-pip
+    - python3-pip
     plugin: make
     build-environment:
     - WEBOTS_HOME: "$SNAPCRAFT_PART_BUILD"
-    - ROS_DISTRO: "melodic"
-    - JAVA_HOME: "/usr/lib/jvm/java-1.11.0-openjdk-amd64"
+    - ROS_DISTRO: "noetic"
+    - JAVA_HOME: "/usr/lib/jvm/java-16-openjdk-amd64"
     - PATH: "$JAVA_HOME/bin:$PATH"
     #source: https://cyberbotics.com/files/repository/beta/webots.tar.bz2
     # When building locally, uncomment the following line:
@@ -96,26 +96,30 @@ parts:
     # source-tag: R2022a
     override-pull: |
       snapcraftctl pull
-      ./scripts/install/linux_optional_compilation_dependencies.sh
+      # ./scripts/install/linux_optional_compilation_dependencies.sh
       sudo apt install --yes xvfb
+      snapcraftctl set-version R2022b
     stage-packages:
-    - openjdk-11-jdk
+    - openjdk-16-jdk
     - ca-certificates-java
     - build-essential
     - libc6-dev
     - ffmpeg
     - freeglut3-dev
+    - libaribb24-0
     - libasn1-8-heimdal
     - libasound2
     - libatk1.0-0
-    - libavutil55
+    - libavutil56
+    - libblas3
     - libblkid1
     - libcanberra-gtk-module
     - libcanberra-gtk3-module
+    - libccd2
     - libcrystalhd3
     - libcurl3-gnutls
     - libdbus-1-3
-    - libdouble-conversion1
+    - libdouble-conversion3
     - libdrm-common
     - libfox-1.6-dev
     - libfreeimage3
@@ -141,7 +145,7 @@ parts:
     - libheimbase1-heimdal
     - libheimntlm0-heimdal
     - libhx509-5-heimdal
-    - libicu60
+    - libicu66
     - libjpeg8-dev
     - libkrb5-26-heimdal
     - libldap-2.4-2
@@ -158,12 +162,9 @@ parts:
     - libopencore-amrwb0
     - libopus0
     - libpcre3
-    - libpoco-dev
-    - libproj12
+    - libproj15
     - libproj-dev
     - libpsl5
-    - libpulse-mainloop-glib0
-    - libpython2.7
     - libroken18-heimdal
     - librtmp1
     - libsasl2-2
@@ -171,18 +172,18 @@ parts:
     - libshine3
     - libslang2
     - libsnappy1v5
-    - libsndio6.1
+    - libsndio7.0
     - libsoxr0
     - libspeex1
     - libssh-dev
     - libssh-gcrypt-4
     - libssl1.1
     - libstdc++6
-    - libswresample2
+    - libswresample3
     - libsystemd0
     - libtheora0
     - libtinfo5
-    - libtinyxml2-6
+    - libtinyxml2-dev
     - libtwolame0
     - libudev1
     - libuuid1
@@ -195,7 +196,7 @@ parts:
     - libwind0-heimdal
     - libx11-data
     - libx11-xcb1
-    - libx265-146
+    - libx265-179
     - libxaw7
     - libxcb-glx0
     - libxcb-icccm4
@@ -229,25 +230,23 @@ parts:
 
 apps:
   webots:
+    extensions: [gnome-3-38]
     environment:
       LANG: C.UTF-8
       LC_ALL: C.UTF-8
       DISABLE_WAYLAND: 1
+      LD_LIBRARY_PATH: $LD_LIBRARAY_PATH:/lib/x86_64-linux-gnu/blas
     plugs:
-    - audio-playback
-    - browser-support
-    - desktop
-    - desktop-legacy
-    - gsettings
-    - hidraw
-    - home
-    - hostname-control
-    - joystick
-    - network
-    - opengl
-    - pulseaudio
-    - wayland
-    - unity7
-    - x11
+      - audio-playback
+      - browser-support
+      - gsettings
+      - hidraw
+      - home
+      - hostname-control
+      - joystick
+      - network
+      - unity7
     desktop: usr/share/webots/resources/webots.desktop
-    command: desktop-launch $SNAP/usr/share/webots/webots
+    command-chain:
+      - bin/desktop-launch
+    command: usr/share/webots/webots


### PR DESCRIPTION
In this PR, I can build a snap on Ubuntu 20.04 with core20, based on https://github.com/cyberbotics/webots/pull/4189, that:
1. Works for recompiling and running C/C++ controllers from the Webots interface.
2. Can run sumo examples (highway.wbt and sumo_interface_example.wbt): fixes all the problems reported in https://github.com/cyberbotics/webots/issues/4036.
3. Can run Python and Java controllers.
