### PR TITLE
Fix snap creation

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -99,6 +99,7 @@ parts:
       ./scripts/install/linux_optional_compilation_dependencies.sh
       sudo apt install --yes xvfb
       snapcraftctl set-version R2022b
+    # libjpeg is conflicting with the one from desktop-gtk3, therefore it is ignored
     stage:
     - -usr/lib/x86_64-linux-gnu/libjpeg.so.8.2.2
     stage-packages:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -54,7 +54,7 @@ parts:
     plugin: make
     source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
     source-subdir: gtk
-    # libjpeg is conflicting with the one from desktop-gtk3, therefore it is ignored
+    # libjpeg is conflicting with the one from webots, therefore it is ignored
     stage:
     - -usr/lib/x86_64-linux-gnu/libjpeg.so.8.2.2
     stage-packages:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -145,7 +145,6 @@ parts:
     - libheimntlm0-heimdal
     - libhx509-5-heimdal
     - libicu66
-    - libjpeg8-dev
     - libkrb5-26-heimdal
     - libldap-2.4-2
     - libltdl7
@@ -226,8 +225,6 @@ parts:
     - lsb-release
     - util-linux
     - zlib1g
-    stage:
-    - usr/lib/x86_64-linux-gnu/libjpeg.so.8.2.2
 
 apps:
   webots:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -99,6 +99,8 @@ parts:
       ./scripts/install/linux_optional_compilation_dependencies.sh
       sudo apt install --yes xvfb
       snapcraftctl set-version R2022b
+    stage:
+    - -usr/lib/x86_64-linux-gnu/libjpeg.so.8.2.2
     stage-packages:
     - openjdk-16-jdk
     - ca-certificates-java
@@ -145,6 +147,7 @@ parts:
     - libheimntlm0-heimdal
     - libhx509-5-heimdal
     - libicu66
+    - libjpeg8-dev
     - libkrb5-26-heimdal
     - libldap-2.4-2
     - libltdl7

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -54,6 +54,9 @@ parts:
     plugin: make
     source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
     source-subdir: gtk
+    # libjpeg is conflicting with the one from desktop-gtk3, therefore it is ignored
+    stage:
+    - -usr/lib/x86_64-linux-gnu/libjpeg.so.8.2.2
     stage-packages:
     - ttf-ubuntu-font-family
     - dmz-cursor-theme
@@ -99,9 +102,6 @@ parts:
       ./scripts/install/linux_optional_compilation_dependencies.sh
       sudo apt install --yes xvfb
       snapcraftctl set-version R2022b
-    # libjpeg is conflicting with the one from desktop-gtk3, therefore it is ignored
-    stage:
-    - -usr/lib/x86_64-linux-gnu/libjpeg.so.8.2.2
     stage-packages:
     - openjdk-16-jdk
     - ca-certificates-java

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -226,6 +226,8 @@ parts:
     - lsb-release
     - util-linux
     - zlib1g
+    stage:
+    - usr/lib/x86_64-linux-gnu/libjpeg.so.8.2.2
 
 apps:
   webots:


### PR DESCRIPTION
Both `desktop-gtk3` and `webots` parts are trying to stage their version of `libjpeg.so.8.2.2`. The one from `desktop-gtk3` is ignored to avoid error at staging time.