### PR TITLE
Fix symlink error

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -102,6 +102,9 @@ parts:
       ./scripts/install/linux_optional_compilation_dependencies.sh
       sudo apt install --yes xvfb
       snapcraftctl set-version R2022b
+    override-prime: |
+      snapcraftctl prime
+      rm -vf usr/lib/jvm/java-11-openjdk-*amd64/lib/security/blacklisted.certs
     stage-packages:
     - openjdk-16-jdk
     - ca-certificates-java


### PR DESCRIPTION
This PR attempts to fix the error reported when uploading the snap to snapstore:

https://dashboard.snapcraft.io/snaps/webots/revisions/23/review/

```
package contains external symlinks: usr/lib/jvm/java-11-openjdk-amd64/lib/security/blacklisted.certs -> /etc/java-11-openjdk/security/blacklisted.certs lint-snap-v2_external_symlinks
```

Inspired by: https://forum.snapcraft.io/t/resolve-package-contains-external-symlinks-error-when-trying-to-snap/2963/20